### PR TITLE
make it work on the latest Nim devel

### DIFF
--- a/nimgame2/audio.nim
+++ b/nimgame2/audio.nim
@@ -30,8 +30,8 @@ import
 
 type
   Channel* = int
-  Distance* = range[0..255]
-  Panning* = range[0..255]
+  Distance* = range[0'u8..255'u8]
+  Panning* = range[0'u8..255'u8]
   Volume* = range[0..mix.MaxVolume]
 
   Sound* = ref object of RootObj


### PR DESCRIPTION
Since [this commit ("Tighten the conversion from tyRange to scalar types") in Nim repo](https://github.com/nim-lang/Nim/commit/71df1b060b272f9c1b6e5a0f393b3a319705cc70), nimgame2 wasn't compiling because of `Distance != uint8` and `Panning != uint8`.