### PR TITLE
Fix soon to be illegal implicit conversion

### DIFF
--- a/nimgame2/input.nim
+++ b/nimgame2/input.nim
@@ -926,7 +926,7 @@ proc movement*(gi: GeneralInput): int =
       if id < 0: 0  # no such joystick opened
       else:
         case gi.joystick.kind:
-        of jAxis: joyAxis(id, gi.joystick.axis)
+        of jAxis: joyAxis(id, gi.joystick.axis).int
         of jBall:
           case gi.joystick.ballDirection:
           of dirX: joyBall(id, gi.joystick.ball).x


### PR DESCRIPTION
See https://github.com/nim-lang/Nim/pull/11197

This code previously relied on an implicit conversion from `int` to a `int16` range. This was never allowed in the spec, but was allowed due to a bug in the compiler.