### PR TITLE
Fix audio issues with multiple sounds playing

### DIFF
--- a/nimgame2/audio.nim
+++ b/nimgame2/audio.nim
@@ -52,7 +52,8 @@ proc free*(sound: Sound) =
   if not (sound.fChunk == nil):
     # check if playing
     if sound.fChannel > -1:
-      if sound.fChannel.playing() > 0:
+      if sound.fChunk == sound.fChannel.getChunk() and
+          sound.fChannel.playing() > 0:
         # halt the channel
         discard sound.fChannel.haltChannel()
     # free
@@ -110,6 +111,11 @@ proc playing*(sound: Sound): bool =
   ##
   if not sound.available:
     return false
+  # Check if this sample is the most recent one that was played on the
+  # channel because a different sample may be currently playing on this
+  # channel instead
+  if sound.fChunk != sound.fChannel.getChunk():
+    return false
   return sound.fChannel.playing() > 0
 
 
@@ -148,6 +154,8 @@ proc paused*(sound: Sound): bool =
   ##  ``Return`` `true` if the ``sound`` is paused, or `false` otherwise.
   ##
   if not sound.available:
+    return false
+  if sound.fChunk != sound.fChannel.getChunk():
     return false
   return sound.fChannel.paused() > 0
 


### PR DESCRIPTION
This pull request fixes some issues I had where multiple sounds that used the same channel were cutting off each other and interacting weirdly in general.

Below is a long explanation of why those issues existed. I was originally going to create an issue for this, but I thought of a solution and fixed the problem directly. This was going to be the text for the issue, but I decided to put it here as an explanation for this pull request.

Suppose there are two sounds which are already loaded that we'll name `a` and `b`. Also, note that in the `audio.play` proc, `playChannel` is called with a channel argument of -1, so SDL_Mixer picks the first free unreserved channel for us.

Then, let's assume this sequence of events happen:
* `a.play()` is called, and it's played on channel 0, setting `a.fChannel` to 0
* `a` finishes playing on channel 0
* `b.play()` is called, and it's played on channel 0 as well since a sound isn't being played there, setting `b.fChannel` to 0
* While `b` is still playing, call `a.playing`

The code of `playing` before this pull request, for reference:
```nim
proc playing*(sound: Sound): bool =
  ##  ``Return`` `true` if the ``sound`` is playing, or `false` otherwise.
  ##
  if not sound.available:
    return false
  return sound.fChannel.playing() > 0
```

Because `a.fChannel` is 0, channel 0 is checked to see if it's playing, but because `b` is still playing on channel 0, that condition is true even though the sound that was being checked is `a`. In other words, different sounds that happen to play on the same channel weren't being distinguished from each other.

Since the `play` proc itself calls `playing` in order to determine if `stop` should be called, this led to weird issues such as sounds cutting off each other and very few mixing channels being used. In this example, if `a.play()` is called while `b` is still playing, `b` will stop playing on channel 0, and then `a` will play on channel 0 since no sounds are playing on it instead of channel 1. Then, if `b` wants to play while `a` is playing, the same thing will happen.

The solution in this pull request is to check if the channel that the sound is associated with is currently playing or had played a different sound since then. If that's the case, the assumption is that the sound being checked cannot be playing or paused.

Let me know if anything needs tweaking.