### PR TITLE
Remove name field from nimble file

### DIFF
--- a/nimgame2.nimble
+++ b/nimgame2.nimble
@@ -1,6 +1,5 @@
 # Package
 
-name          = "nimgame2"
 version       = "0.6.2"
 author        = "Vladar"
 description   = "A simple 2D game engine for Nim language."


### PR DESCRIPTION
Partially reverts #49

This breaks `nimble check` with `undeclared identifier: 'name'`. `name` seems to be a legacy field that was removed in some version of Nimble, evidenced by https://github.com/nim-lang/nimble/issues/237.